### PR TITLE
bugfix: raise an exception if the server disconnects

### DIFF
--- a/o3d3xx/pcic/client.py
+++ b/o3d3xx/pcic/client.py
@@ -20,6 +20,8 @@ class Client(object):
         data = bytearray()
         while len(data) < numberBytes:
             dataPart = self.pcicSocket.recv(numberBytes - len(data))
+            if len(dataPart) == 0:
+                raise RuntimeError('connection to server closed')
             data = data + dataPart
         self.recvCounter += numberBytes
         if self.outFile != None:


### PR DESCRIPTION
Currently, the client enters an endless loop if the connection to the server is lost.
This fix raises an RuntimeError instead